### PR TITLE
fix(comments): Use compatible format for gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An array of patterns to ensure are present in the specified `.gitignore` file. A
 
 #### comment (?string)
 
-Appended to each pattern that is being ensured to indicate what is programmatically being controlled.
+Prepended to the list of provided pattens at the bottom of the file, to indicate which patterns are being controlled programmatically.
 
 ```js
 const ensureGitignore = require('ensure-gitignore');

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ await ensureGitignore({
 });
 
 // =>
-// node_modules # managed
-// output # managed
+// # managed
+// node_modules
+// output
 //
 ```
 


### PR DESCRIPTION
Use comment pattern that is compatible with `.gitignore` file format. Comments must be on their own line rather than on the end of the pattern line 🤦‍♂️ 