### PR TITLE
feat(remove): Wrap controlled patterns in comment block 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,23 @@ An array of patterns to ensure are present in the specified `.gitignore` file. A
 
 <a id="comment">
 
-#### comment (?string)
+#### comment (?string, default: 'managed')
 
-Prepended to the list of provided pattens at the bottom of the file, to indicate which patterns are being controlled programmatically.
+Allows you to document the list of patterns that are being controlled programmatically. This helps provide context as to why/what is controlling certain patterns within a `.gitignore` file.
 
 ```js
 const ensureGitignore = require('ensure-gitignore');
 
 await ensureGitignore({
   patterns: ['node_modules', 'output'],
-  comment: 'managed'
+  comment: 'managed by build script'
 });
 
 // =>
-// # managed
+// # managed by build script
 // node_modules
 // output
+// # end managed by build script
 //
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An array of patterns to ensure are present in the specified `.gitignore` file. A
 
 #### comment (?string)
 
-Appended to each pattern that is being ensured to indicate what is programmatically being controlled.
+Prepended to the list of provided pattens at the bottom of the file, to indicate which patterns are being controlled programmatically.
 
 ```js
 const ensureGitignore = require('ensure-gitignore');

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An array of patterns to ensure are present in the specified `.gitignore` file. A
 
 <a id="comment">
 
-#### comment (?string, default: 'managed')
+#### comment (?string, default: 'managed by ensure-gitignore')
 
 Allows you to document the list of patterns that are being controlled programmatically. This helps provide context as to why/what is controlling certain patterns within a `.gitignore` file. Anything inside the comment block will be re-written on each run.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An array of patterns to ensure are present in the specified `.gitignore` file. A
 
 #### comment (?string, default: 'managed by ensure-gitignore')
 
-Allows you to document the list of patterns that are being controlled programmatically. This helps provide context as to why/what is controlling certain patterns within a `.gitignore` file. Anything inside the comment block will be re-written on each run.
+Allows you to document the list of patterns that are being controlled programmatically. This helps provide context as to what is controlling certain patterns within a `.gitignore` file. Anything inside the comment block will be re-written on each run, including the removal of old patterns that are no longer managed.
 
 ```js
 const ensureGitignore = require('ensure-gitignore');

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ await ensureGitignore({
 });
 
 // =>
-// node_modules # managed
-// output # managed
+// # managed
+// node_modules
+// output
 //
 ```
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const trimArray = arr =>
 
 module.exports = async ({
   patterns = [],
-  comment = 'managed',
+  comment = 'managed by ensure-gitignore',
   filepath = path.resolve(process.cwd(), '.gitignore'),
   dryRun = false
 }) => {

--- a/index.js
+++ b/index.js
@@ -21,14 +21,19 @@ module.exports = async ({
   const sortedPatterns = patterns.sort();
   const contents = await readFile(filepath, 'utf-8');
   const userSpecified = contents
+    .trim()
     .split(/\r?\n/)
     .filter(pattern => !sortedPatterns.includes(pattern));
 
+  const commentString = `# ${comment}\n`;
+  const commentStringRegEx = new RegExp(`\r?\n${commentString}`, 'g');
+  const stripOldComment = str => str.replace(commentStringRegEx, '');
+
   const outputPatterns = [
-    userSpecified.join('\n').trim(),
+    stripOldComment(userSpecified.join('\n')).trim(),
     sortedPatterns.join('\n').trim()
   ]
-    .join(`\n\n${comment ? `# ${comment}\n` : ''}`)
+    .join(`\n\n${comment ? commentString : ''}`)
     .trim();
   const output = `${outputPatterns}\n`;
 

--- a/index.js
+++ b/index.js
@@ -12,29 +12,46 @@ const write = async (filepath, output, dryRun) => {
   return output;
 };
 
+const trimArray = arr =>
+  arr
+    .join('\n')
+    .trim()
+    .split('\n');
+
 module.exports = async ({
   patterns = [],
-  comment = '',
+  comment = 'managed',
   filepath = path.resolve(process.cwd(), '.gitignore'),
   dryRun = false
 }) => {
   const sortedPatterns = patterns.sort();
   const contents = await readFile(filepath, 'utf-8');
-  const userSpecified = contents
+  const rawPatterns = contents
     .trim()
     .split(/\r?\n/)
     .filter(pattern => !sortedPatterns.includes(pattern));
 
-  const commentString = `# ${comment}\n`;
-  const commentStringRegEx = new RegExp(`\r?\n${commentString}`, 'g');
-  const stripOldComment = str => str.replace(commentStringRegEx, '');
+  const startComment = `# ${comment}`;
+  const endComment = `# end ${comment}`;
+  const startIndex = rawPatterns.indexOf(startComment);
+  const endIndex = rawPatterns.indexOf(endComment);
 
-  const outputPatterns = [
-    stripOldComment(userSpecified.join('\n')).trim(),
-    sortedPatterns.join('\n').trim()
-  ]
-    .join(`\n\n${comment ? commentString : ''}`)
+  const before =
+    startIndex > 0 ? trimArray(rawPatterns.slice(0, startIndex)) : rawPatterns;
+  const after =
+    endIndex > 0
+      ? trimArray(rawPatterns.slice(rawPatterns.indexOf(endComment) + 1))
+      : [];
+
+  const controlledPatterns =
+    patterns.length > 0
+      ? [`\n${startComment}`, ...sortedPatterns, endComment]
+      : [];
+
+  const outputPatterns = [...before, ...controlledPatterns, ...after]
+    .join('\n')
     .trim();
+
   const output = `${outputPatterns}\n`;
 
   return contents !== output ? write(filepath, output, dryRun) : output;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,9 +51,9 @@ b
 c
 d
 
-# managed
+# managed by ensure-gitignore
 e
-# end managed
+# end managed by ensure-gitignore
 "
 `);
   });
@@ -72,9 +72,9 @@ b
 c
 d
 
-# managed
+# managed by ensure-gitignore
 e
-# end managed
+# end managed by ensure-gitignore
 "
 `);
   });
@@ -83,7 +83,7 @@ e
     const output = await ensureGitignore({
       patterns: ['e'],
       filepath: path.join(__dirname, 'output/append'),
-      comment: 'managed externally',
+      comment: 'custom comment',
       dryRun: true
     });
     expect(output).toMatchInlineSnapshot(`
@@ -92,9 +92,9 @@ b
 c
 d
 
-# managed externally
+# custom comment
 e
-# end managed externally
+# end custom comment
 "
 `);
   });
@@ -103,7 +103,7 @@ e
     const output = await ensureGitignore({
       patterns: ['a/**'],
       filepath: path.join(__dirname, 'output/append'),
-      comment: 'managed externally',
+      comment: 'custom comment',
       dryRun: true
     });
     expect(output).toMatchInlineSnapshot(`
@@ -111,9 +111,9 @@ e
 c
 d
 
-# managed externally
+# custom comment
 a/**
-# end managed externally
+# end custom comment
 "
 `);
   });
@@ -130,9 +130,9 @@ b
 c
 d
 
-# managed
+# managed by ensure-gitignore
 a
-# end managed
+# end managed by ensure-gitignore
 "
 `);
   });
@@ -148,10 +148,10 @@ a
 c
 d
 
-# managed
+# managed by ensure-gitignore
 b
 f
-# end managed
+# end managed by ensure-gitignore
 "
 `);
   });
@@ -173,13 +173,17 @@ f
     afterEach(() => fs.unlinkSync(filepath));
 
     it('write take control existing', async () => {
-      await ensureGitignore({ patterns: ['a'], comment: 'managed', filepath });
+      await ensureGitignore({
+        patterns: ['a'],
+        comment: 'custom comment',
+        filepath
+      });
       expect(read(filepath)).toEqual(
         `b
 
-# managed
+# custom comment
 a
-# end managed
+# end custom comment
 `
       );
     });
@@ -187,22 +191,22 @@ a
     it('write with existing comment', async () => {
       await ensureGitignore({
         patterns: ['c'],
-        comment: 'managed',
+        comment: 'custom comment',
         filepath
       });
       await ensureGitignore({
         patterns: ['d', 'e'],
-        comment: 'managed',
+        comment: 'custom comment',
         filepath
       });
       expect(read(filepath)).toEqual(
         `a
 b
 
-# managed
+# custom comment
 d
 e
-# end managed
+# end custom comment
 `
       );
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,7 +51,9 @@ b
 c
 d
 
+# managed
 e
+# end managed
 "
 `);
   });
@@ -70,7 +72,9 @@ b
 c
 d
 
+# managed
 e
+# end managed
 "
 `);
   });
@@ -90,6 +94,7 @@ d
 
 # managed externally
 e
+# end managed externally
 "
 `);
   });
@@ -108,11 +113,12 @@ d
 
 # managed externally
 a/**
+# end managed externally
 "
 `);
   });
 
-  it('take over ignore exact only', async () => {
+  it('take over ignore exact', async () => {
     const output = await ensureGitignore({
       patterns: ['a'],
       filepath: path.join(__dirname, 'output/append'),
@@ -124,7 +130,9 @@ b
 c
 d
 
+# managed
 a
+# end managed
 "
 `);
   });
@@ -140,8 +148,10 @@ a
 c
 d
 
+# managed
 b
 f
+# end managed
 "
 `);
   });
@@ -169,12 +179,17 @@ f
 
 # managed
 a
+# end managed
 `
       );
     });
 
     it('write with existing comment', async () => {
-      await ensureGitignore({ patterns: ['c'], comment: 'managed', filepath });
+      await ensureGitignore({
+        patterns: ['c'],
+        comment: 'managed',
+        filepath
+      });
       await ensureGitignore({
         patterns: ['d', 'e'],
         comment: 'managed',
@@ -183,11 +198,11 @@ a
       expect(read(filepath)).toEqual(
         `a
 b
-c
 
 # managed
 d
 e
+# end managed
 `
       );
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -159,14 +159,35 @@ f
   describe('file system test', async () => {
     const filepath = path.join(__dirname, 'output/write');
 
-    beforeAll(() => fs.writeFileSync(filepath, '', 'utf-8'));
-    afterAll(() => fs.unlinkSync(filepath));
+    beforeEach(() => fs.writeFileSync(filepath, 'a\nb', 'utf-8'));
+    afterEach(() => fs.unlinkSync(filepath));
 
-    it('write', async () => {
+    it('write take control existing', async () => {
       await ensureGitignore({ patterns: ['a'], comment: 'managed', filepath });
       expect(read(filepath)).toEqual(
-        `# managed
+        `b
+
+# managed
 a
+`
+      );
+    });
+
+    it('write with existing comment', async () => {
+      await ensureGitignore({ patterns: ['c'], comment: 'managed', filepath });
+      await ensureGitignore({
+        patterns: ['d', 'e'],
+        comment: 'managed',
+        filepath
+      });
+      expect(read(filepath)).toEqual(
+        `a
+b
+c
+
+# managed
+d
+e
 `
       );
     });


### PR DESCRIPTION
Supports removing controlled patterns from `.gitignore`. The patterns are now written to the `.gitignore` file inside a comment block. This block is re-written on every run of the script, so any manual changes to the patterns inside the block will be discarded on subsequent runs.