### PR TITLE
fix(index): Ensure only one controlled block is written

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ module.exports = async ({
   const endIndex = rawPatterns.indexOf(endComment);
 
   const before =
-    startIndex > 0 ? trimArray(rawPatterns.slice(0, startIndex)) : rawPatterns;
+    startIndex >= 0 ? trimArray(rawPatterns.slice(0, startIndex)) : rawPatterns;
   const after =
-    endIndex > 0
+    endIndex >= 0
       ? trimArray(rawPatterns.slice(rawPatterns.indexOf(endComment) + 1))
       : [];
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -189,6 +189,31 @@ a
       );
     });
 
+    it('ensure controlled patterns block isnt duplicated', async () => {
+      const onlyControlledPatterns = path.join(
+        __dirname,
+        'output/noduplicateblock'
+      );
+
+      await ensureGitignore({
+        patterns: ['a'],
+        filepath: onlyControlledPatterns
+      });
+      await ensureGitignore({
+        patterns: ['a'],
+        filepath: onlyControlledPatterns
+      });
+      const contents = await readFile(onlyControlledPatterns);
+      await removeFile(onlyControlledPatterns);
+
+      expect(contents).toEqual(
+        `# managed by ensure-gitignore
+a
+# end managed by ensure-gitignore
+`
+      );
+    });
+
     it('write take control existing', async () => {
       await ensureGitignore({
         patterns: ['a'],


### PR DESCRIPTION
An ignore file that contained only controlled patterns was having multiple comment blocks written out as the previous comment block was not being trimmed out.