### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @front-end-contributors
+*       @seek-oss/front-end-contributors


### PR DESCRIPTION
This was flagged by a bug bounty but there's no way to actually exploit taking over the `front-end-contributors` group.

<img width="931" height="439" alt="image" src="https://github.com/user-attachments/assets/690db901-a734-408c-8b1c-632af4739bfe" />
